### PR TITLE
Call original addNPC and addPC functions

### DIFF
--- a/scripts/manager_effect_adnd.lua
+++ b/scripts/manager_effect_adnd.lua
@@ -34,7 +34,7 @@ function onInit()
 
   -- back up old CoreRPG functions
   addPC_old = CombatManager.addPC;
-  addNPC_old = CombatManager2.addNPC;
+  addNPC_old = CombatManager.addNPC;
 
   -- CoreRPG replacements
   ActionsManager.decodeActors = decodeActors;


### PR DESCRIPTION
This calls the original addNPC and addPC functions rather than duplicating their code in your extension. Doing this should make it less time-consuming for you to keep it updated when the 5E ruleset changes and also improve its compatibility with other extensions.

The only downside I see in doing this to addNPC is that pinned effects modifying initiative will not be used for the automatic initiative roll when adding the NPC as the effects are added after the NPC initiative is rolled. You could have it reroll afterwards, but "nodeLastMatch" will not be available so it would still be a compromise as each NPC would have its own initiative (rather than grouping by type).

I have not tested these changes very much as I also do not use 5E, but I made these changes to my Pathfinder/3.5E port and it seems to be working great over there. I did open 5E with these changes and just drag a NPC and a PC into the combat tracker and they copied in without script errors and with their advanced effects.

This is the last pull request I'm planning to open on your repo. I thought it would be nice to contribute the simplifications I came up with when working on the PFRPG port 😃 