### PR TITLE
Update advanced_effects_editor.lua

### DIFF
--- a/utility/scripts/advanced_effects_editor.lua
+++ b/utility/scripts/advanced_effects_editor.lua
@@ -60,7 +60,7 @@ function update()
     local bSave = (sType == "save");
     local bAbility = (sType == "ability");
     local bSusceptiblity = (sType == "susceptiblity");
-    local bMisc = (sType == "misc");
+    local bMisc = (sType == "misc_ae");
     
     local w = Interface.findWindow("advanced_effect_editor", "");
 --Debug.console("advanced_effects_editor.lua","update","save",save);


### PR DESCRIPTION
In commit d60bad7d2d5377671ba8db6ee8c7e094a3ce395d, "misc" was changed to "misc_ae" everywhere else in the extension.
I think you missed this one.