### PR TITLE
Ammunition Manager ActionOnly Effects

### DIFF
--- a/campaign/scripts/char_weapon_adnd.lua
+++ b/campaign/scripts/char_weapon_adnd.lua
@@ -11,15 +11,10 @@ function onAttackAction(draginfo)
 	local rAction = CharWeaponManager.buildAttackAction(nodeChar, nodeWeapon);
 
 	-- Decrement ammo
-	-- bmos removing redundant ammo counting
-	-- for compatibility with ammunition tracker, make this change in your char_weapon.lua
-	if not AmmunitionManager then
-		CharWeaponManager.decrementAmmo(nodeChar, nodeWeapon);
-	end
-	-- end bmos removing redundant ammo counting
+	CharWeaponManager.decrementAmmo(nodeChar, nodeWeapon);
 
 	-- Perform action
-	local rActor = ActorManager.resolveActor( nodeChar);
+	local rActor = ActorManager.resolveActor(nodeChar);
 
 	-- add itemPath to rActor so that when effects are checked we can 
 	-- make compare against action only effects
@@ -34,19 +29,29 @@ function onAttackAction(draginfo)
 			rActor.ammoPath = nodeAmmo.getPath()
 		end
 	end
-	-- bmos only allowing attacks when ammo is sufficient
-	-- for compatibility with ammunition tracker, make this change in your char_weapon.lua
-	-- this if section replaces the two commented out lines above:
-	-- "ActionAttack.performRoll(draginfo, rActor, rAction);" and "return true;"
-	local nMaxAmmo = DB.getValue(nodeWeapon, 'maxammo', 0)
-	local nMaxAttacks = nMaxAmmo - DB.getValue(nodeWeapon, 'ammo', 0)
-	if not AmmunitionManager or (not (nMaxAmmo > 0) or (nMaxAttacks >= 1)) then	
+	--end bmos adding ammoPath
+
+	-- bmos adding AmmoManager loading weapon support and checking for ammo
+	if not AmmunitionManager then	
 		ActionAttack.performRoll(draginfo, rActor, rAction);
 		return true;
 	else
-		ChatManager.Message(Interface.getString("char_message_atkwithnoammo"), true, rActor);
+		local bLoading = DB.getValue(nodeWeapon, 'properties', ''):lower():find('loading') ~= nil
+		local bIsLoaded = DB.getValue(nodeWeapon, 'isloaded', 0) == 1
+		if not bLoading or (bLoading and bIsLoaded) then
+			if (bInfiniteAmmo or nAmmo > 0) then	
+				if bLoading then DB.setValue(nodeWeapon, 'isloaded', 'number', 0); end
+				ActionAttack.performRoll(draginfo, rActor, rAction);
+				return true;
+			else
+				ChatManager.Message(Interface.getString("char_message_atkwithnoammo"), true, rActor);
+				if bLoading then DB.setValue(nodeWeapon, 'isloaded', 'number', 0); end
+			end
+		else
+			ChatManager.Message(string.format(Interface.getString('char_actions_notloaded'), DB.getValue(nodeWeapon, 'name', 'weapon')), true, rActor);
+		end
 	end
-	-- end bmos only allowing attacks when ammo is sufficient
+	-- end bmos adding loading weapon and ammo check support
 end
 
 function onDamageAction(draginfo)
@@ -57,13 +62,22 @@ function onDamageAction(draginfo)
 	local rAction = CharWeaponManager.buildDamageAction(nodeChar, nodeWeapon);
 
 	-- Perform damage action
-	local rActor = ActorManager.resolveActor( nodeChar);
+	local rActor = ActorManager.resolveActor(nodeChar);
 
 	-- add itemPath to rActor so that when effects are checked we can 
 	-- make compare against action only effects
 	local _, sRecord = DB.getValue(nodeWeapon, "shortcut", "", "");
 	rActor.itemPath = sRecord;
 	-- end Adanced Effects Piece ---
+
+	-- bmos adding AmmunitionManager integration
+	if AmmunitionManager then
+		local nodeAmmo = AmmunitionManager.getAmmoNode(nodeWeapon, rActor)
+		if nodeAmmo then
+			rActor.ammoPath = nodeAmmo.getPath()
+		end
+	end
+	-- end bmos adding ammoPath
 	
 	ActionDamage.performRoll(draginfo, rActor, rAction);
 	return true;

--- a/campaign/scripts/char_weapon_adnd.lua
+++ b/campaign/scripts/char_weapon_adnd.lua
@@ -27,6 +27,13 @@ function onAttackAction(draginfo)
 	rActor.itemPath = sRecord;
 	-- end Adanced Effects Piece ---
 
+	-- bmos adding AmmunitionManager integration
+	if AmmunitionManager then
+		local nodeAmmo = AmmunitionManager.getAmmoNode(nodeWeapon, rActor)
+		if nodeAmmo then
+			rActor.ammoPath = nodeAmmo.getPath()
+		end
+	end
 	-- bmos only allowing attacks when ammo is sufficient
 	-- for compatibility with ammunition tracker, make this change in your char_weapon.lua
 	-- this if section replaces the two commented out lines above:

--- a/scripts/manager_effect_adnd.lua
+++ b/scripts/manager_effect_adnd.lua
@@ -947,7 +947,10 @@ function manager_action_damage_performRoll(draginfo, rActor, rAction)
     if (draginfo and rActor.itemPath and rActor.itemPath ~= "") then
         draginfo.setMetaData("itemPath",rActor.itemPath);
     end
-	
+	if AmmunitionManager and (draginfo and rActor.ammoPath and rActor.ammoPath ~= "") then
+		draginfo.setMetaData("ammoPath", rActor.ammoPath);
+	end
+
 	ActionsManager.performAction(draginfo, rActor, rRoll);
 end
 
@@ -959,7 +962,10 @@ function manager_action_attack_performRoll(draginfo, rActor, rAction)
     if (draginfo and rActor.itemPath and rActor.itemPath ~= "") then
         draginfo.setMetaData("itemPath",rActor.itemPath);
     end
-    
+	if AmmunitionManager and (draginfo and rActor.ammoPath and rActor.ammoPath ~= "") then
+		draginfo.setMetaData("ammoPath", rActor.ammoPath);
+	end
+
 	ActionsManager.performAction(draginfo, rActor, rRoll);
 end
 

--- a/scripts/manager_effect_adnd.lua
+++ b/scripts/manager_effect_adnd.lua
@@ -537,55 +537,50 @@ function sendRawMessage(sUser, nDMOnly, msg)
   end
 end
 
+---	This function returns false if the effect is tied to an item and the item is not being used.
+function isValidCheckEffect(rActor, nodeEffect)
+	if DB.getValue(nodeEffect, "isactive", 0) ~= 0 then
+		local bItem, bActionItemUsed, bActionOnly = false, false, false
+		local sItemPath = ""
 
--- pass effect to here to see if the effect is being triggered
--- by an item and if so if it's valid
-function isValidCheckEffect(rActor,nodeEffect)
-    local bResult = false;
-    local nActive = DB.getValue(nodeEffect, "isactive", 0);
-    local bItem = false;
-    local bActionItemUsed = false;
-    local bActionOnly = false;
-    local nodeItem = nil;
+		local sSource = DB.getValue(nodeEffect,"source_name","");
+		-- if source is a valid node and we can find "actiononly"
+		-- setting then we set it.
+		local node = DB.findNode(sSource);
+		if node then
+			local nodeItem = node.getChild("...");
+			if nodeItem then
+				sItemPath = nodeItem.getPath();
+				bActionOnly = (DB.getValue(node,"actiononly",0) ~= 0);
+			end
+		end
 
-    local sSource = DB.getValue(nodeEffect,"source_name","");
-    -- if source is a valid node and we can find "actiononly"
-    -- setting then we set it.
-    local node = DB.findNode(sSource);
-    if (node and node ~= nil) then
-        nodeItem = node.getChild("...");
-        if nodeItem and nodeItem ~= nil then
-            bActionOnly = (DB.getValue(node,"actiononly",0) ~= 0);
-        end
-    end
+		if sItemPath and sItemPath ~= "" then
+			-- if there is a nodeWeapon do some sanity checking
+			if rActor.nodeWeapon then
+				-- here is where we get the node path of the item, not the
+				-- effectslist entry
+				if bActionOnly and (sItemPath == rActor.nodeWeapon) then
+					bActionItemUsed = true;
+				end
+			end
 
-    -- if there is a itemPath do some sanity checking
-    if (rActor.itemPath and rActor.itemPath ~= "") then 
-        -- here is where we get the node path of the item, not the 
-        -- effectslist entry
-        if ((DB.findNode(rActor.itemPath) ~= nil)) then
-            if (node and node ~= nil and nodeItem and nodeItem ) then
-                local sNodePath = nodeItem.getPath();
-                if bActionOnly and sNodePath ~= "" and (sNodePath == rActor.itemPath) then
-                    bActionItemUsed = true;
-                    bItem = true;
-                else
-                    bActionItemUsed = false;
-                    bItem = true; -- is item but doesn't match source path for this effect
-                end
-            end
-        end
-    end
-    if nActive ~= 0 and bActionOnly and bActionItemUsed then
-        bResult = true;
-    elseif nActive ~= 0 and not bActionOnly and bActionItemUsed then
-        bResult = true;
-    elseif nActive ~= 0 and bActionOnly and not bActionItemUsed then
-        bResult = false;
-    elseif nActive ~= 0 then
-        bResult = true;
-    end
-    return bResult;
+			-- if there is a nodeAmmo do some sanity checking
+			if AmmunitionManager and rActor.nodeAmmo then
+				-- here is where we get the node path of the item, not the
+				-- effectslist entry
+				if bActionOnly and (sItemPath == rActor.nodeAmmo) then
+					bActionItemUsed = true;
+				end
+			end
+		end
+		
+		if bActionOnly and not bActionItemUsed then
+			return false;
+		else
+			return true;
+		end
+	end
 end
 
 

--- a/scripts/manager_effect_adnd.lua
+++ b/scripts/manager_effect_adnd.lua
@@ -983,6 +983,9 @@ function manager_power_performAction(draginfo, rActor, rAction, nodePower)
 		if nodeAmmo then
 			rActor.ammoPath = nodeAmmo.getPath()
 		end
+		if (draginfo and rActor.ammoPath and rActor.ammoPath ~= "") then
+			draginfo.setMetaData("ammoPath", rActor.ammoPath);
+		end
 	end
  
     if (draginfo and rActor.itemPath and rActor.itemPath ~= "") then


### PR DESCRIPTION
Effects attached to ammo used with a weapon during an attack will be counted.
Also rewrites decodeActors to call original function for compatibility.
Works as before when Ammunition Manager is not present.

This also upgrades the compatibility code I put here earlier.